### PR TITLE
Fix #23 #15

### DIFF
--- a/VketBoothValidator/Assets/VketBoothValidator/Editor/Rules/G_ComponentLimitation/G99_MonoBehaviorListRule.cs
+++ b/VketBoothValidator/Assets/VketBoothValidator/Editor/Rules/G_ComponentLimitation/G99_MonoBehaviorListRule.cs
@@ -50,7 +50,7 @@ namespace VketTools
                         }
                         if (cmp != null)
                         {
-                            string cmpInfo = string.Format("{0} ({1})", cmp.gameObject.name, cmp.GetType().FullName);
+                            string cmpInfo = string.Format(" {0} ({1})", cmp.gameObject.name, cmp.GetType().FullName);
                             AddResultLog(cmpInfo);
                         }
                         else

--- a/VketBoothValidator/Assets/VketBoothValidator/Editor/VketBoothValidator.cs
+++ b/VketBoothValidator/Assets/VketBoothValidator/Editor/VketBoothValidator.cs
@@ -159,7 +159,7 @@ namespace VketTools
         private void OutLog(string txt)
         {
             Debug.Log(txt);
-            validationLog += txt + System.Environment.NewLine;
+            validationLog += System.Environment.NewLine + txt;
         }
 
         private void OutLog(BaseRule rule, bool onlyErrorLog)
@@ -175,7 +175,9 @@ namespace VketTools
                 Debug.Log(rule.RuleName + ":" + rule.ResultLog);
                 if (!onlyErrorLog)
                 {
-                    validationLog += rule.ResultLog + System.Environment.NewLine;
+                    if (rule.ResultLog != "") { 
+                        validationLog += System.Environment.NewLine + rule.ResultLog + System.Environment.NewLine;
+                    }
                 }
             }
 


### PR DESCRIPTION
ログの見易さ修正。
@gatosyocora いかがでしょうか？
```

Start vket booth validation. (2019.3 Beta)
Base folder:circlename_yourname
Scene file:Assets/circlename_yourname/circlename_yourname.unity
Unity version:2017.4.15f1

全角文字使用アセット数：0

180文字を超える長いパス：0

シーン内の次のオブジェクトはブースに含まれないです。
 Main Camera
 Directional Light
 ScaleLimitVisualizer

[!]Ð01.ブースサイズ Rule
ブースのサイズ:(4.000, 5.000, 5.420)
奥行(Z)が3を2.42超えています。

アクティブな使用マテリアル:
 Assets/circlename_yourname/Materials/material1.mat
 Assets/circlename_yourname/Materials/material2.mat
 Assets/circlename_yourname/Materials/material3.mat
 Assets/circlename_yourname/Materials/material4.mat
 Assets/circlename_yourname/Materials/material5.mat
 Assets/circlename_yourname/Materials/material6.mat
 Assets/circlename_yourname/Materials/material7.mat
 Assets/circlename_yourname/Materials/material8.mat
 Assets/circlename_yourname/Materials/material9.mat
 Assets/circlename_yourname/Materials/material10.mat
シーン内マテリアル数：10

ブース内のMonoBehavior：
Cube (DynamicBone)

---
1件のルール違反が見つかりました。
Finish validation
```