### PR TITLE
Feature/#24

### DIFF
--- a/VketBoothValidator/Assets/VketBoothValidator/Editor/RuleLoader.cs
+++ b/VketBoothValidator/Assets/VketBoothValidator/Editor/RuleLoader.cs
@@ -37,6 +37,7 @@ namespace VketTools
             new BoothPrefabRule(options),
             //B
             new NonAlphabeticalCharactersRule(options),
+            new FilenameEndWithTildeRule(options),
             new FilePathLengthRule(options),
             //C
             new ObjectHierarchyRule(options),

--- a/VketBoothValidator/Assets/VketBoothValidator/Editor/Rules/B_NameFormat/B04_FilenameEndWithTildeRule.cs
+++ b/VketBoothValidator/Assets/VketBoothValidator/Editor/Rules/B_NameFormat/B04_FilenameEndWithTildeRule.cs
@@ -41,7 +41,8 @@ namespace VketTools
             foreach (string guid in dictinctGuids)
             {
                 assetPath = AssetDatabase.GUIDToAssetPath(guid);
-                if (Path.GetFileNameWithoutExtension(assetPath).EndsWith(prohibitedCharacter))
+                if (Path.GetFileName(assetPath).EndsWith(prohibitedCharacter) ||
+                    Path.GetFileNameWithoutExtension(assetPath).EndsWith(prohibitedCharacter))
                 {
                     invalidPath.Add(assetPath);
                 }

--- a/VketBoothValidator/Assets/VketBoothValidator/Editor/Rules/B_NameFormat/B04_FilenameEndWithTildeRule.cs
+++ b/VketBoothValidator/Assets/VketBoothValidator/Editor/Rules/B_NameFormat/B04_FilenameEndWithTildeRule.cs
@@ -1,0 +1,66 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEditor;
+using UnityEditor.SceneManagement;
+using UnityEngine;
+using System;
+using System.IO;
+using System.Text.RegularExpressions;
+using System.Linq;
+
+namespace VketTools
+{
+    /// <summary>
+    /// B.ファイル&フォルダ名規定
+    /// 04:ファイル、フォルダ名の終わりの「~」禁止
+    /// </summary>
+    public class FilenameEndWithTildeRule : BaseRule
+    {
+        public new string ruleName = "B04:ファイル、フォルダ名の終わりの「~」禁止 rule";
+        public override string RuleName
+        {
+            get
+            {
+                return ruleName;
+            }
+        }
+        public FilenameEndWithTildeRule(Options _options) : base(_options)
+        {
+        }
+        public override Result Validate()
+        {
+            base.Validate();
+            Result result;
+            string prohibitedCharacter = "~";
+            int expectedCount = 0;
+
+            string[] guids = AssetDatabase.FindAssets("t:Object", new[] { AssetDatabase.GetAssetPath(options.baseFolder) });
+            IEnumerable<string> dictinctGuids = guids.Distinct();
+            string assetPath;
+            List<string> invalidPath = new List<string>();
+            foreach (string guid in dictinctGuids)
+            {
+                assetPath = AssetDatabase.GUIDToAssetPath(guid);
+                if (Path.GetFileNameWithoutExtension(assetPath).EndsWith(prohibitedCharacter))
+                {
+                    invalidPath.Add(assetPath);
+                }
+            }
+            AddResultLog(string.Format("名前の末尾に'{0}'が含まれるアセット：{1}", prohibitedCharacter, invalidPath.Count));
+            foreach (string path in invalidPath.ToArray())
+            {
+                AddResultLog(path);
+            }
+
+            if (invalidPath.Count == expectedCount)
+            {
+                result = Result.SUCCESS;
+            }
+            else
+            {
+                result = Result.FAIL;
+            }
+            return SetResult(result);
+        }
+    }
+}

--- a/VketBoothValidator/Assets/VketBoothValidator/Editor/Rules/B_NameFormat/B04_FilenameEndWithTildeRule.cs.meta
+++ b/VketBoothValidator/Assets/VketBoothValidator/Editor/Rules/B_NameFormat/B04_FilenameEndWithTildeRule.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1da59b95c23290d4daf4049b96e4091c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
#24 実装。
終わりの「~」禁止
ヒットするテストデータをコミットするとプロジェクト起動時にエラーが出て煩雑なのでローカルでのみテスト。

foldername~
filename~.mat
filename~.fbx
